### PR TITLE
map log level numeric enum to string values

### DIFF
--- a/__mocks__/environment.js
+++ b/__mocks__/environment.js
@@ -1,0 +1,3 @@
+export default function setupEnvironment() {
+    process.env.FOO_BAR = 'foo_bar'
+}

--- a/__mocks__/environment.js
+++ b/__mocks__/environment.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-process-env */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function setupEnvironment() {
-    process.env.FOO_BAR = 'foo_bar'
+    process.env.FOO_BAR = 'foo_bar';
 }

--- a/__mocks__/setup.test.js
+++ b/__mocks__/setup.test.js
@@ -1,5 +1,6 @@
+/* eslint-disable no-process-env */
 describe('test environment', () => {
     test('process.env.foo equals "bar"', () => {
-        expect(process.env.foo).toBe('bar');
+        expect(process.env.FOO_BAR).toBe('foo_bar');
     });
 });

--- a/example.ts
+++ b/example.ts
@@ -1,7 +1,7 @@
-import { Logger, LoggerLevel } from './src/Logger';
+import { Logger, LogLevel } from './src/Logger';
 
 (function main() {
-    const appLogger = new Logger({ name: 'myApp', namespace: 'app', level: LoggerLevel.silly });
+    const appLogger = new Logger({ name: 'myApp', namespace: 'app', level: LogLevel.silly });
     appLogger.silly({
         message: 'you are awesome.',
         foo: 'test foo',

--- a/src/Logger.test.js
+++ b/src/Logger.test.js
@@ -1,11 +1,12 @@
+/* eslint-disable no-void */
 import { Exception } from '@specialblend/exceptional';
 import { taggedMocks } from '@specialblend/tagged-mocks';
 import flatten from 'flat';
 
 import createLogger, { Logger, LogLevel } from './Logger';
 
-console.log = jest.fn(console.log);
-console.error = jest.fn(console.error);
+console.log = jest.fn(void console.log);
+console.error = jest.fn(void console.error);
 
 const $LOG_LEVELS = [
     ['LoggerLevel.fatal', LogLevel.FATAL, console.error],

--- a/src/Logger.test.js
+++ b/src/Logger.test.js
@@ -2,19 +2,19 @@ import { Exception } from '@specialblend/exceptional';
 import { taggedMocks } from '@specialblend/tagged-mocks';
 import flatten from 'flat';
 
-import createLogger, { Logger, LoggerLevel } from './Logger';
+import createLogger, { Logger, LogLevel } from './Logger';
 
 console.log = jest.fn(console.log);
 console.error = jest.fn(console.error);
 
 const $LOG_LEVELS = [
-    ['LoggerLevel.fatal', LoggerLevel.fatal, console.error],
-    ['LoggerLevel.error', LoggerLevel.error, console.error],
-    ['LoggerLevel.debug', LoggerLevel.debug, console.log],
-    ['LoggerLevel.warn', LoggerLevel.warn, console.log],
-    ['LoggerLevel.info', LoggerLevel.info, console.log],
-    ['LoggerLevel.trace', LoggerLevel.trace, console.log],
-    ['LoggerLevel.silly', LoggerLevel.silly, console.log],
+    ['LoggerLevel.fatal', LogLevel.FATAL, console.error],
+    ['LoggerLevel.error', LogLevel.error, console.error],
+    ['LoggerLevel.debug', LogLevel.debug, console.log],
+    ['LoggerLevel.warn', LogLevel.warn, console.log],
+    ['LoggerLevel.info', LogLevel.info, console.log],
+    ['LoggerLevel.trace', LogLevel.trace, console.log],
+    ['LoggerLevel.silly', LogLevel.silly, console.log],
 ];
 
 describe('createLogger', () => {
@@ -35,7 +35,7 @@ describe('createLogger', () => {
                     });
                     describe('when called', () => {
                         test('returns expected object', () => {
-                            const $level = LoggerLevel.fatal;
+                            const $level = LogLevel.FATAL;
                             const $data = {
                                 foo: 'test.foo',
                                 bar: 'test.bar',
@@ -59,7 +59,7 @@ describe('createLogger', () => {
                     });
                     describe('when called', () => {
                         test('returns expected string', () => {
-                            const $level = LoggerLevel.fatal;
+                            const $level = LogLevel.FATAL;
                             const $data = {
                                 foo: 'test.foo',
                                 bar: 'test.bar',
@@ -90,7 +90,7 @@ describe('createLogger', () => {
                     });
                     describe('when called', () => {
                         test('returns expected object', () => {
-                            const $level = LoggerLevel.fatal;
+                            const $level = LogLevel.FATAL;
                             const $data = {
                                 foo: 'test.foo',
                                 bar: 'test.bar',
@@ -115,7 +115,7 @@ describe('createLogger', () => {
                     });
                     describe('when called', () => {
                         test('returns expected string', () => {
-                            const $level = LoggerLevel.fatal;
+                            const $level = LogLevel.FATAL;
                             const $data = {
                                 foo: 'test.foo',
                                 bar: 'test.bar',
@@ -139,7 +139,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp',
                 namespace: 'testNamespace',
-                level: LoggerLevel.silly,
+                level: LogLevel.silly,
             };
             const $fancyMetadata = {
                 alpha: 'alpha.test',
@@ -163,7 +163,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -181,7 +181,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -199,7 +199,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -217,7 +217,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -235,7 +235,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -253,7 +253,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -271,7 +271,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -312,7 +312,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -330,7 +330,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -348,7 +348,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -366,7 +366,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.warn, $myFancyChildLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -384,7 +384,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.info, $myFancyChildLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -402,7 +402,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.trace, $myFancyChildLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -420,7 +420,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -455,7 +455,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -473,7 +473,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -491,7 +491,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -509,7 +509,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -527,7 +527,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -545,7 +545,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -563,7 +563,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -598,7 +598,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -616,7 +616,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -634,7 +634,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -652,7 +652,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -670,7 +670,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -688,7 +688,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -706,7 +706,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -720,7 +720,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp',
                 namespace: 'testNamespace',
-                level: LoggerLevel.silly,
+                level: LogLevel.silly,
             };
             const $fancyMetadata = {
                 alpha: 'alpha.test',
@@ -744,7 +744,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -762,7 +762,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -780,7 +780,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -798,7 +798,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -816,7 +816,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -834,7 +834,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -852,7 +852,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -893,7 +893,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -911,7 +911,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -929,7 +929,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -947,7 +947,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.warn, $myFancyChildLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -965,7 +965,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.info, $myFancyChildLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -983,7 +983,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.trace, $myFancyChildLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1001,7 +1001,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1036,7 +1036,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1054,7 +1054,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1072,7 +1072,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1090,7 +1090,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1108,7 +1108,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1126,7 +1126,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1144,7 +1144,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1179,7 +1179,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1197,7 +1197,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1215,7 +1215,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1233,7 +1233,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1251,7 +1251,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1269,7 +1269,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1287,7 +1287,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1301,7 +1301,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp1',
                 namespace: 'testNamespace1',
-                level: LoggerLevel.trace,
+                level: LogLevel.trace,
             };
             const $fancyMetadata = {
                 alpha1: 'alpha.test1',
@@ -1325,7 +1325,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1343,7 +1343,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1361,7 +1361,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1379,7 +1379,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1397,7 +1397,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1415,7 +1415,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1433,7 +1433,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1474,7 +1474,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1492,7 +1492,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1510,7 +1510,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.warn, $myFancyChildLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1528,7 +1528,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1546,7 +1546,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.info, $myFancyChildLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1564,7 +1564,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.trace, $myFancyChildLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1582,7 +1582,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1617,7 +1617,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1635,7 +1635,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1653,7 +1653,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1671,7 +1671,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1689,7 +1689,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1707,7 +1707,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1725,7 +1725,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1760,7 +1760,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1778,7 +1778,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1796,7 +1796,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1814,7 +1814,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1832,7 +1832,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1850,7 +1850,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.trace, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1868,7 +1868,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1882,7 +1882,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp2',
                 namespace: 'testNamespace2',
-                level: LoggerLevel.info,
+                level: LogLevel.info,
             };
             const $fancyMetadata = {
                 alpha2: 'alpha.test2',
@@ -1906,7 +1906,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1924,7 +1924,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1942,7 +1942,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1960,7 +1960,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1978,7 +1978,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1996,7 +1996,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2014,7 +2014,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2055,7 +2055,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2073,7 +2073,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2091,7 +2091,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.warn, $myFancyChildLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2109,7 +2109,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2127,7 +2127,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.info, $myFancyChildLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2145,7 +2145,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2163,7 +2163,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2198,7 +2198,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2216,7 +2216,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2234,7 +2234,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2252,7 +2252,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2270,7 +2270,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2288,7 +2288,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2306,7 +2306,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2341,7 +2341,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2359,7 +2359,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2377,7 +2377,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2395,7 +2395,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2413,7 +2413,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.info, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2431,7 +2431,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2449,7 +2449,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2463,7 +2463,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp3',
                 namespace: 'testNamespace3',
-                level: LoggerLevel.warn,
+                level: LogLevel.warn,
             };
             const $fancyMetadata = {
                 alpha1: 'alpha.test1',
@@ -2487,7 +2487,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2505,7 +2505,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2523,7 +2523,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2541,7 +2541,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2559,7 +2559,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2577,7 +2577,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2595,7 +2595,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -2636,7 +2636,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2654,7 +2654,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2672,7 +2672,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2690,7 +2690,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.warn, $myFancyChildLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2708,7 +2708,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2726,7 +2726,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2744,7 +2744,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2779,7 +2779,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2797,7 +2797,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2815,7 +2815,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2833,7 +2833,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2851,7 +2851,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2869,7 +2869,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2887,7 +2887,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2922,7 +2922,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2940,7 +2940,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2958,7 +2958,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2976,7 +2976,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.warn, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -2994,7 +2994,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3012,7 +3012,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3030,7 +3030,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3044,7 +3044,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp4',
                 namespace: 'testNamespace4',
-                level: LoggerLevel.debug,
+                level: LogLevel.debug,
             };
             const $fancyMetadata = {
                 alpha4: 'alpha.test4',
@@ -3068,7 +3068,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3086,7 +3086,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3104,7 +3104,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3122,7 +3122,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3140,7 +3140,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3158,7 +3158,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3176,7 +3176,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3217,7 +3217,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3235,7 +3235,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3253,7 +3253,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.debug, $myFancyChildLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3271,7 +3271,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3289,7 +3289,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3307,7 +3307,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3325,7 +3325,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3360,7 +3360,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3378,7 +3378,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3396,7 +3396,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3414,7 +3414,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3432,7 +3432,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3450,7 +3450,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3468,7 +3468,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3503,7 +3503,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3521,7 +3521,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3539,7 +3539,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.debug, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3557,7 +3557,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3575,7 +3575,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3593,7 +3593,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3611,7 +3611,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3625,7 +3625,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp5',
                 namespace: 'testNamespace5',
-                level: LoggerLevel.error,
+                level: LogLevel.error,
             };
             const $fancyMetadata = {
                 alpha5: 'alpha.test5',
@@ -3649,7 +3649,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3667,7 +3667,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3685,7 +3685,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3703,7 +3703,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3721,7 +3721,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3739,7 +3739,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3757,7 +3757,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3798,7 +3798,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3816,7 +3816,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.error, $myFancyChildLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3834,7 +3834,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3852,7 +3852,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3870,7 +3870,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3888,7 +3888,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3906,7 +3906,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3941,7 +3941,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3959,7 +3959,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3977,7 +3977,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3995,7 +3995,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4013,7 +4013,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4031,7 +4031,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4049,7 +4049,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4084,7 +4084,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4102,7 +4102,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.error, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4120,7 +4120,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4138,7 +4138,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4156,7 +4156,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4174,7 +4174,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4192,7 +4192,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4206,7 +4206,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp6',
                 namespace: 'testNamespace6',
-                level: LoggerLevel.fatal,
+                level: LogLevel.FATAL,
             };
             const $fancyMetadata = {
                 alpha5: 'alpha.test5',
@@ -4230,7 +4230,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.fatal($data);
                         });
                         test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.fatal, $myFancyLogger.constructMessage(LoggerLevel.fatal, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4248,7 +4248,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4266,7 +4266,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4284,7 +4284,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4302,7 +4302,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4320,7 +4320,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4338,7 +4338,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.silly, $myFancyLogger.constructMessage(LoggerLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4379,7 +4379,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.fatal, $myFancyChildLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4397,7 +4397,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4415,7 +4415,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4433,7 +4433,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4451,7 +4451,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4469,7 +4469,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4487,7 +4487,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LoggerLevel.silly, $myFancyChildLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4522,7 +4522,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4540,7 +4540,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4558,7 +4558,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4576,7 +4576,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4594,7 +4594,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4612,7 +4612,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4630,7 +4630,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4665,7 +4665,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.fatal($data);
                                     });
                                     test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.fatal, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.fatal, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4683,7 +4683,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.error, $myFancyLogger.constructMessage(LoggerLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4701,7 +4701,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.debug, $myFancyLogger.constructMessage(LoggerLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4719,7 +4719,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.warn, $myFancyLogger.constructMessage(LoggerLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4737,7 +4737,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.info, $myFancyLogger.constructMessage(LoggerLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4755,7 +4755,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LoggerLevel.trace, $myFancyLogger.constructMessage(LoggerLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4773,7 +4773,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LoggerLevel.silly, $mySuperFancySiblingLogger.constructMessage(LoggerLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4787,7 +4787,7 @@ describe('MyFancyLogger extends Logger', () => {
     describe('exception', () => {
         const $name = 'testApp00';
         const $namespace = 'testNamespace00';
-        const $logger = new MyFancyLogger({ name: $name, namespace: $namespace, level: LoggerLevel.silly });
+        const $logger = new MyFancyLogger({ name: $name, namespace: $namespace, level: LogLevel.silly });
         test('is Function', () => {
             expect($logger.exception).toBeFunction();
         });
@@ -4812,7 +4812,7 @@ describe('MyFancyLogger extends Logger', () => {
                             message: $exMessage,
                             data: $exData,
                         };
-                        const $expectedMessagePayload = $logger.constructMessage(LoggerLevel.error, $expectedData);
+                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.error, $expectedData);
                         expect(console.error).toHaveBeenCalledWith(expect.any(String));
                         const [[$stringPayload]] = console.error.mock.calls;
                         expect(JSON.parse($stringPayload)).toMatchObject(flatten($expectedMessagePayload));
@@ -4871,7 +4871,7 @@ describe('MyFancyLogger extends Logger', () => {
                                 stack: $err.stack,
                             },
                         };
-                        const $expectedMessagePayload = $logger.constructMessage(LoggerLevel.error, $expectedData);
+                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.error, $expectedData);
                         expect(console.error).toHaveBeenCalledWith(expect.any(String));
                         const [[$stringPayload]] = console.error.mock.calls;
                         expect(JSON.parse($stringPayload)).toMatchObject(flatten($expectedMessagePayload));

--- a/src/Logger.test.js
+++ b/src/Logger.test.js
@@ -9,13 +9,13 @@ console.log = jest.fn(void console.log);
 console.error = jest.fn(void console.error);
 
 const $LOG_LEVELS = [
-    ['LoggerLevel.fatal', LogLevel.FATAL, console.error],
-    ['LoggerLevel.error', LogLevel.error, console.error],
-    ['LoggerLevel.debug', LogLevel.debug, console.log],
-    ['LoggerLevel.warn', LogLevel.warn, console.log],
-    ['LoggerLevel.info', LogLevel.info, console.log],
-    ['LoggerLevel.trace', LogLevel.trace, console.log],
-    ['LoggerLevel.silly', LogLevel.silly, console.log],
+    ['LoggerLevel.FATAL', LogLevel.FATAL, console.error],
+    ['LoggerLevel.ERROR', LogLevel.ERROR, console.error],
+    ['LoggerLevel.WARN', LogLevel.WARN, console.log],
+    ['LoggerLevel.INFO', LogLevel.INFO, console.log],
+    ['LoggerLevel.DEBUG', LogLevel.DEBUG, console.log],
+    ['LoggerLevel.TRACE', LogLevel.TRACE, console.log],
+    ['LoggerLevel.SILLY', LogLevel.SILLY, console.log],
 ];
 
 describe('createLogger', () => {
@@ -24,7 +24,10 @@ describe('createLogger', () => {
     });
     describe('when called', () => {
         describe('with no metadata', () => {
-            const $options = { name: 'testApp', namespace: 'testNamespace' };
+            const $options = {
+                name: 'testApp',
+                namespace: 'testNamespace',
+            };
             const $logger = createLogger($options);
             test('it returns instanceof Logger', () => {
                 expect($logger).toBeInstanceOf(Logger);
@@ -48,7 +51,7 @@ describe('createLogger', () => {
                                 name: $options.name,
                                 type: $expectedType,
                                 [$expectedType]: {
-                                    ... $data,
+                                    ...$data,
                                 },
                             });
                         });
@@ -75,7 +78,10 @@ describe('createLogger', () => {
             });
         });
         describe('with metadata', () => {
-            const $options = { name: 'testApp', namespace: 'testNamespace' };
+            const $options = {
+                name: 'testApp',
+                namespace: 'testNamespace',
+            };
             const $metadata = {
                 alpha: 'alpha.test',
                 bravo: 'bravo.test',
@@ -100,11 +106,11 @@ describe('createLogger', () => {
                             const $message = $logger.constructMessage($level, $data);
                             expect($message).toBeInstanceOf(Object);
                             expect($message).toMatchObject({
-                                ... $metadata,
+                                ...$metadata,
                                 name: $options.name,
                                 type: $expectedType,
                                 [$expectedType]: {
-                                    ... $data,
+                                    ...$data,
                                 },
                             });
                         });
@@ -134,13 +140,15 @@ describe('createLogger', () => {
 });
 
 describe('MyFancyLogger extends Logger', () => {
-    class MyFancyLogger extends Logger {}
+    class MyFancyLogger extends Logger {
+    }
+
     describe('when called', () => {
         describe('without loglevel', () => {
             const $options = {
                 name: 'testApp',
                 namespace: 'testNamespace',
-                level: LogLevel.silly,
+                level: LogLevel.SILLY,
             };
             const $fancyMetadata = {
                 alpha: 'alpha.test',
@@ -182,26 +190,8 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('debug', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.debug).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.debug($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
                 });
@@ -218,7 +208,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -236,7 +226,25 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('debug', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.debug).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.debug($data);
+                        });
+                        test('writes to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -254,7 +262,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -272,7 +280,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -295,8 +303,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -331,7 +339,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -349,7 +357,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.DEBUG, $myFancyChildLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -367,7 +375,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.WARN, $myFancyChildLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -385,7 +393,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.INFO, $myFancyChildLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -403,7 +411,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.TRACE, $myFancyChildLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -421,7 +429,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -474,7 +482,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -492,7 +500,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -510,7 +518,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -528,7 +536,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -546,7 +554,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -564,7 +572,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -617,7 +625,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -635,7 +643,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -653,7 +661,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -671,7 +679,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -689,7 +697,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -707,7 +715,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -721,7 +729,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp',
                 namespace: 'testNamespace',
-                level: LogLevel.silly,
+                level: LogLevel.SILLY,
             };
             const $fancyMetadata = {
                 alpha: 'alpha.test',
@@ -763,7 +771,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -781,7 +789,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -799,7 +807,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -817,7 +825,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -835,7 +843,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -853,7 +861,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -876,8 +884,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -912,7 +920,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -930,7 +938,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.DEBUG, $myFancyChildLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -948,7 +956,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.WARN, $myFancyChildLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -966,7 +974,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.INFO, $myFancyChildLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -984,7 +992,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.TRACE, $myFancyChildLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1002,7 +1010,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1055,7 +1063,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1073,7 +1081,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1091,7 +1099,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1109,7 +1117,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1127,7 +1135,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1145,7 +1153,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1198,7 +1206,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1216,7 +1224,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1234,7 +1242,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1252,7 +1260,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1270,7 +1278,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1288,7 +1296,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1302,7 +1310,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp1',
                 namespace: 'testNamespace1',
-                level: LogLevel.trace,
+                level: LogLevel.TRACE,
             };
             const $fancyMetadata = {
                 alpha1: 'alpha.test1',
@@ -1344,7 +1352,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1362,7 +1370,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1380,7 +1388,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1398,7 +1406,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1416,7 +1424,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1434,7 +1442,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -1457,8 +1465,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -1493,7 +1501,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1511,7 +1519,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.WARN, $myFancyChildLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1529,7 +1537,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.DEBUG, $myFancyChildLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1547,7 +1555,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.INFO, $myFancyChildLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1565,7 +1573,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.trace, $myFancyChildLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.TRACE, $myFancyChildLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1583,7 +1591,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1636,7 +1644,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1654,7 +1662,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1672,7 +1680,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1690,7 +1698,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1708,7 +1716,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1726,7 +1734,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1779,7 +1787,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1797,7 +1805,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1815,7 +1823,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1833,7 +1841,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1851,7 +1859,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.trace, $mySuperFancySiblingLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.TRACE, $mySuperFancySiblingLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -1869,1169 +1877,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-        describe('when loglevel = LoggerLevel.info', () => {
-            const $options = {
-                name: 'testApp2',
-                namespace: 'testNamespace2',
-                level: LogLevel.info,
-            };
-            const $fancyMetadata = {
-                alpha2: 'alpha.test2',
-                bravo2: 'bravo.test2',
-            };
-            const $myFancyLogger = new MyFancyLogger($options, $fancyMetadata);
-            test('it returns instance of Logger', () => {
-                expect($myFancyLogger).toBeInstanceOf(Logger);
-            });
-            describe('logger method', () => {
-                describe('fatal', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.fatal).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.fatal($data);
-                        });
-                        test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
-                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('error', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.error).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.error($data);
-                        });
-                        test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
-                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('debug', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.debug).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.debug($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('warn', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.warn).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.warn($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('info', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.info).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.info($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('trace', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.trace).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.trace($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('silly', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.silly).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.silly($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-            });
-            describe('method', () => {
-                describe('child', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.child).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $superFancyMetadata = {
-                            fancy: 'shmancy',
-                        };
-                        const $myFancyChildLogger = $myFancyLogger.child($superFancyMetadata);
-                        test('it returns expected Logger', () => {
-                            expect($myFancyChildLogger).toBeInstanceOf(Logger);
-                            expect($myFancyChildLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($myFancyChildLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
-                            expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
-                            expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
-                            });
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.info($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.info, $myFancyChildLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-                describe('sibling', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.sibling).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $namespace = 'super_fancy_namespace';
-                        const $mySuperFancySiblingLogger = $myFancyLogger.sibling($namespace);
-                        test('it returns expected Logger', () => {
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-                describe('type', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.type).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $namespace = 'super_fancy_namespace';
-                        const $mySuperFancySiblingLogger = $myFancyLogger.type($namespace);
-                        test('it returns expected Logger', () => {
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.info, $mySuperFancySiblingLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-            });
-        });
-        describe('when loglevel = LoggerLevel.warn', () => {
-            const $options = {
-                name: 'testApp3',
-                namespace: 'testNamespace3',
-                level: LogLevel.warn,
-            };
-            const $fancyMetadata = {
-                alpha1: 'alpha.test1',
-                bravo1: 'bravo.test1',
-            };
-            const $myFancyLogger = new MyFancyLogger($options, $fancyMetadata);
-            test('it returns instance of Logger', () => {
-                expect($myFancyLogger).toBeInstanceOf(Logger);
-            });
-            describe('logger method', () => {
-                describe('fatal', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.fatal).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.fatal($data);
-                        });
-                        test('calls expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
-                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('error', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.error).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.error($data);
-                        });
-                        test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
-                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('debug', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.debug).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.debug($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('warn', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.warn).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.warn($data);
-                        });
-                        test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('info', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.info).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.info($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('trace', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.trace).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.trace($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('silly', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.silly).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.silly($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-            });
-            describe('method', () => {
-                describe('child', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.child).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $superFancyMetadata = {
-                            fancy: 'shmancy',
-                        };
-                        const $myFancyChildLogger = $myFancyLogger.child($superFancyMetadata);
-                        test('it returns expected Logger', () => {
-                            expect($myFancyChildLogger).toBeInstanceOf(Logger);
-                            expect($myFancyChildLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($myFancyChildLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
-                            expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
-                            expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
-                            });
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.warn, $myFancyChildLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-                describe('sibling', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.sibling).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $namespace = 'super_fancy_namespace';
-                        const $mySuperFancySiblingLogger = $myFancyLogger.sibling($namespace);
-                        test('it returns expected Logger', () => {
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                        });
-                    });
-                });
-                describe('type', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.type).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $namespace = 'super_fancy_namespace';
-                        const $mySuperFancySiblingLogger = $myFancyLogger.type($namespace);
-                        test('it returns expected Logger', () => {
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
-                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
-                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
-                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
-                        });
-                        describe('logger method', () => {
-                            describe('fatal', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.fatal($data);
-                                    });
-                                    test('calls expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('error', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.error($data);
-                                    });
-                                    test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
-                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('debug', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.debug($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.warn, $mySuperFancySiblingLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('trace', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.trace($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('silly', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.silly($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3045,7 +1891,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp4',
                 namespace: 'testNamespace4',
-                level: LogLevel.debug,
+                level: LogLevel.DEBUG,
             };
             const $fancyMetadata = {
                 alpha4: 'alpha.test4',
@@ -3087,8 +1933,46 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+
+                describe('warn', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.warn).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.warn($data);
+                        });
+                        test('writes to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                        });
+
+                    });
+                });
+                describe('info', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.info).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.info($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
                 });
@@ -3105,44 +1989,8 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('writes to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('warn', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.warn).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.warn($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                        });
-                    });
-                });
-                describe('info', () => {
-                    test('is Function', () => {
-                        expect($myFancyLogger.info).toBeFunction();
-                    });
-                    describe('when called', () => {
-                        const $data = {
-                            foo: 'test.foo',
-                            bar: 'test.bar',
-                        };
-                        beforeAll(() => {
-                            $myFancyLogger.info($data);
-                        });
-                        test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
-                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
                 });
@@ -3159,7 +2007,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3177,7 +2025,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3200,8 +2048,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -3236,8 +2084,44 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.info($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
@@ -3254,44 +2138,8 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.debug, $myFancyChildLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.DEBUG, $myFancyChildLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.warn($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($myFancyChildLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $myFancyChildLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
@@ -3308,7 +2156,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3326,7 +2174,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3379,8 +2227,45 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('does write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('does write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
@@ -3397,44 +2282,8 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
@@ -3451,7 +2300,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3469,7 +2318,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3522,8 +2371,44 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('does write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('does write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
@@ -3540,47 +2425,12 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('writes to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.debug, $mySuperFancySiblingLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
                             });
-                            describe('warn', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.warn($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
-                            describe('info', () => {
-                                test('is Function', () => {
-                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
-                                });
-                                describe('when called', () => {
-                                    const $data = {
-                                        foo: 'test.foo',
-                                        bar: 'test.bar',
-                                    };
-                                    beforeAll(() => {
-                                        $mySuperFancySiblingLogger.info($data);
-                                    });
-                                    test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
-                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
-                                    });
-                                });
-                            });
+
                             describe('trace', () => {
                                 test('is Function', () => {
                                     expect($mySuperFancySiblingLogger.trace).toBeFunction();
@@ -3594,7 +2444,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3612,7 +2462,1171 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+        describe('when loglevel = LoggerLevel.info', () => {
+            const $options = {
+                name: 'testApp2',
+                namespace: 'testNamespace2',
+                level: LogLevel.INFO,
+            };
+            const $fancyMetadata = {
+                alpha2: 'alpha.test2',
+                bravo2: 'bravo.test2',
+            };
+            const $myFancyLogger = new MyFancyLogger($options, $fancyMetadata);
+            test('it returns instance of Logger', () => {
+                expect($myFancyLogger).toBeInstanceOf(Logger);
+            });
+            describe('logger method', () => {
+                describe('fatal', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.fatal).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.fatal($data);
+                        });
+                        test('calls expected stderr with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
+                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('error', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.error).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.error($data);
+                        });
+                        test('writes to expected stderr with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
+                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('warn', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.warn).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.warn($data);
+                        });
+                        test('writes to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('info', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.info).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.info($data);
+                        });
+                        test('writes to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('debug', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.debug).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.debug($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('trace', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.trace).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.trace($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('silly', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.silly).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.silly($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+            });
+            describe('method', () => {
+                describe('child', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.child).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $superFancyMetadata = {
+                            fancy: 'shmancy',
+                        };
+                        const $myFancyChildLogger = $myFancyLogger.child($superFancyMetadata);
+                        test('it returns expected Logger', () => {
+                            expect($myFancyChildLogger).toBeInstanceOf(Logger);
+                            expect($myFancyChildLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($myFancyChildLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
+                            expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
+                            expect($myFancyChildLogger.metadata).toMatchObject({
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
+                            });
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.WARN, $myFancyChildLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.info($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.INFO, $myFancyChildLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+                describe('sibling', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.sibling).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $namespace = 'super_fancy_namespace';
+                        const $mySuperFancySiblingLogger = $myFancyLogger.sibling($namespace);
+                        test('it returns expected Logger', () => {
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+                describe('type', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.type).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $namespace = 'super_fancy_namespace';
+                        const $mySuperFancySiblingLogger = $myFancyLogger.type($namespace);
+                        test('it returns expected Logger', () => {
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.INFO, $mySuperFancySiblingLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+        describe('when loglevel = LoggerLevel.warn', () => {
+            const $options = {
+                name: 'testApp3',
+                namespace: 'testNamespace3',
+                level: LogLevel.WARN,
+            };
+            const $fancyMetadata = {
+                alpha1: 'alpha.test1',
+                bravo1: 'bravo.test1',
+            };
+            const $myFancyLogger = new MyFancyLogger($options, $fancyMetadata);
+            test('it returns instance of Logger', () => {
+                expect($myFancyLogger).toBeInstanceOf(Logger);
+            });
+            describe('logger method', () => {
+                describe('fatal', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.fatal).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.fatal($data);
+                        });
+                        test('calls expected stderr with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.FATAL, $myFancyLogger.constructMessage(LogLevel.FATAL, $data));
+                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('error', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.error).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.error($data);
+                        });
+                        test('writes to expected stderr with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
+                            expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+
+                describe('warn', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.warn).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.warn($data);
+                        });
+                        test('writes to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
+                            expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('info', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.info).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.info($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('debug', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.debug).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.debug($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('trace', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.trace).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.trace($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+                describe('silly', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.silly).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $data = {
+                            foo: 'test.foo',
+                            bar: 'test.bar',
+                        };
+                        beforeAll(() => {
+                            $myFancyLogger.silly($data);
+                        });
+                        test('does NOT write to expected stdout with expected payload', () => {
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
+                            expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                        });
+                    });
+                });
+            });
+            describe('method', () => {
+                describe('child', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.child).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $superFancyMetadata = {
+                            fancy: 'shmancy',
+                        };
+                        const $myFancyChildLogger = $myFancyLogger.child($superFancyMetadata);
+                        test('it returns expected Logger', () => {
+                            expect($myFancyChildLogger).toBeInstanceOf(Logger);
+                            expect($myFancyChildLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($myFancyChildLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
+                            expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
+                            expect($myFancyChildLogger.metadata).toMatchObject({
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
+                            });
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.FATAL, $myFancyChildLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.DEBUG, $myFancyChildLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.WARN, $myFancyChildLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.info($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($myFancyChildLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $myFancyChildLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+                describe('sibling', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.sibling).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $namespace = 'super_fancy_namespace';
+                        const $mySuperFancySiblingLogger = $myFancyLogger.sibling($namespace);
+                        test('it returns expected Logger', () => {
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+                describe('type', () => {
+                    test('is Function', () => {
+                        expect($myFancyLogger.type).toBeFunction();
+                    });
+                    describe('when called', () => {
+                        const $namespace = 'super_fancy_namespace';
+                        const $mySuperFancySiblingLogger = $myFancyLogger.type($namespace);
+                        test('it returns expected Logger', () => {
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(Logger);
+                            expect($mySuperFancySiblingLogger).toBeInstanceOf(MyFancyLogger);
+                            expect($mySuperFancySiblingLogger.options.name).toBe($myFancyLogger.options.name);
+                            expect($mySuperFancySiblingLogger.options.namespace).toBe($namespace);
+                        });
+                        describe('logger method', () => {
+                            describe('fatal', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.fatal).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.fatal($data);
+                                    });
+                                    test('calls expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.FATAL, $mySuperFancySiblingLogger.constructMessage(LogLevel.FATAL, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('error', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.error).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.error($data);
+                                    });
+                                    test('writes to expected stderr with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
+                                        expect(console.error).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('warn', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.warn).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.warn($data);
+                                    });
+                                    test('writes to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.WARN, $mySuperFancySiblingLogger.constructMessage(LogLevel.WARN, $data));
+                                        expect(console.log).toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('info', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.info).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.info($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('debug', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.debug).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.debug($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.DEBUG, $mySuperFancySiblingLogger.constructMessage(LogLevel.DEBUG, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('trace', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.trace).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.trace($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
+                                        expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
+                                    });
+                                });
+                            });
+                            describe('silly', () => {
+                                test('is Function', () => {
+                                    expect($mySuperFancySiblingLogger.silly).toBeFunction();
+                                });
+                                describe('when called', () => {
+                                    const $data = {
+                                        foo: 'test.foo',
+                                        bar: 'test.bar',
+                                    };
+                                    beforeAll(() => {
+                                        $mySuperFancySiblingLogger.silly($data);
+                                    });
+                                    test('does NOT write to expected stdout with expected payload', () => {
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3626,7 +3640,7 @@ describe('MyFancyLogger extends Logger', () => {
             const $options = {
                 name: 'testApp5',
                 namespace: 'testNamespace5',
-                level: LogLevel.error,
+                level: LogLevel.ERROR,
             };
             const $fancyMetadata = {
                 alpha5: 'alpha.test5',
@@ -3668,7 +3682,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('writes to expected stderr with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.error).toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3686,7 +3700,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3704,7 +3718,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3722,7 +3736,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3740,7 +3754,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3758,7 +3772,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -3781,8 +3795,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -3817,7 +3831,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.error, $myFancyChildLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.ERROR, $myFancyChildLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3835,7 +3849,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3853,7 +3867,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3871,7 +3885,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3889,7 +3903,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3907,7 +3921,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3960,7 +3974,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3978,7 +3992,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -3996,7 +4010,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4014,7 +4028,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4032,7 +4046,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4050,7 +4064,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4103,7 +4117,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('writes to expected stderr with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.error, $mySuperFancySiblingLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.ERROR, $mySuperFancySiblingLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.error).toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4121,7 +4135,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4139,7 +4153,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4157,7 +4171,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4175,7 +4189,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4193,7 +4207,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4249,7 +4263,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.error($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4267,7 +4281,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.debug($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4285,7 +4299,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.warn($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4303,7 +4317,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.info($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4321,7 +4335,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.trace($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4339,7 +4353,7 @@ describe('MyFancyLogger extends Logger', () => {
                             $myFancyLogger.silly($data);
                         });
                         test('does NOT write to expected stdout with expected payload', () => {
-                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.silly, $myFancyLogger.constructMessage(LogLevel.silly, $data));
+                            const $expectedMessage = $myFancyLogger.serialize(LogLevel.SILLY, $myFancyLogger.constructMessage(LogLevel.SILLY, $data));
                             expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                         });
                     });
@@ -4362,8 +4376,8 @@ describe('MyFancyLogger extends Logger', () => {
                             expect($myFancyChildLogger.options.namespace).toBe($myFancyLogger.options.namespace);
                             expect($myFancyChildLogger.metadata).toBeInstanceOf(Object);
                             expect($myFancyChildLogger.metadata).toMatchObject({
-                                ... $fancyMetadata,
-                                ... $superFancyMetadata,
+                                ...$fancyMetadata,
+                                ...$superFancyMetadata,
                             });
                         });
                         describe('logger method', () => {
@@ -4398,7 +4412,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4416,7 +4430,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4434,7 +4448,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4452,7 +4466,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4470,7 +4484,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4488,7 +4502,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $myFancyChildLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.silly, $myFancyChildLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $myFancyChildLogger.serialize(LogLevel.SILLY, $myFancyChildLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4541,7 +4555,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4559,7 +4573,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4577,7 +4591,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4595,7 +4609,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4613,7 +4627,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4631,7 +4645,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4684,7 +4698,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.error($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.error, $myFancyLogger.constructMessage(LogLevel.error, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.ERROR, $myFancyLogger.constructMessage(LogLevel.ERROR, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4702,7 +4716,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.debug($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.debug, $myFancyLogger.constructMessage(LogLevel.debug, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.DEBUG, $myFancyLogger.constructMessage(LogLevel.DEBUG, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4720,7 +4734,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.warn($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.warn, $myFancyLogger.constructMessage(LogLevel.warn, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.WARN, $myFancyLogger.constructMessage(LogLevel.WARN, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4738,7 +4752,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.info($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.info, $myFancyLogger.constructMessage(LogLevel.info, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.INFO, $myFancyLogger.constructMessage(LogLevel.INFO, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4756,7 +4770,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.trace($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.trace, $myFancyLogger.constructMessage(LogLevel.trace, $data));
+                                        const $expectedMessage = $myFancyLogger.serialize(LogLevel.TRACE, $myFancyLogger.constructMessage(LogLevel.TRACE, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4774,7 +4788,7 @@ describe('MyFancyLogger extends Logger', () => {
                                         $mySuperFancySiblingLogger.silly($data);
                                     });
                                     test('does NOT write to expected stdout with expected payload', () => {
-                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.silly, $mySuperFancySiblingLogger.constructMessage(LogLevel.silly, $data));
+                                        const $expectedMessage = $mySuperFancySiblingLogger.serialize(LogLevel.SILLY, $mySuperFancySiblingLogger.constructMessage(LogLevel.SILLY, $data));
                                         expect(console.log).not.toHaveBeenCalledWith($expectedMessage);
                                     });
                                 });
@@ -4788,7 +4802,11 @@ describe('MyFancyLogger extends Logger', () => {
     describe('exception', () => {
         const $name = 'testApp00';
         const $namespace = 'testNamespace00';
-        const $logger = new MyFancyLogger({ name: $name, namespace: $namespace, level: LogLevel.silly });
+        const $logger = new MyFancyLogger({
+            name: $name,
+            namespace: $namespace,
+            level: LogLevel.SILLY,
+        });
         test('is Function', () => {
             expect($logger.exception).toBeFunction();
         });
@@ -4813,7 +4831,7 @@ describe('MyFancyLogger extends Logger', () => {
                             message: $exMessage,
                             data: $exData,
                         };
-                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.error, $expectedData);
+                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.ERROR, $expectedData);
                         expect(console.error).toHaveBeenCalledWith(expect.any(String));
                         const [[$stringPayload]] = console.error.mock.calls;
                         expect(JSON.parse($stringPayload)).toMatchObject(flatten($expectedMessagePayload));
@@ -4872,7 +4890,7 @@ describe('MyFancyLogger extends Logger', () => {
                                 stack: $err.stack,
                             },
                         };
-                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.error, $expectedData);
+                        const $expectedMessagePayload = $logger.constructMessage(LogLevel.ERROR, $expectedData);
                         expect(console.error).toHaveBeenCalledWith(expect.any(String));
                         const [[$stringPayload]] = console.error.mock.calls;
                         expect(JSON.parse($stringPayload)).toMatchObject(flatten($expectedMessagePayload));

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -67,8 +67,8 @@ export class Logger {
         return this.sibling(namespace);
     }
 
-    public log<TData extends Record<string, any>>(log_level: ILogLevel, data: TData): void {
-        const [level] = parseLogLevel(log_level);
+    public log<TData extends Record<string, any>>(logLevel: ILogLevel, data: TData): void {
+        const [level] = parseLogLevel(logLevel);
         if (level <= this.options.level) {
             const payloadRecord = this.constructMessage(level, data);
             const payloadStr = this.serialize<TData>(level, payloadRecord);


### PR DESCRIPTION
### Changed
- [BREAKING] rename `enum LoggerLevel` to `enum LogLevel`
- [BREAKING] reorder log levels: move `DEBUG` to between `INFO` and `TRACE`
- map log level numeric values to string values